### PR TITLE
chore: Add Close method for proper gRPC client resource management

### DIFF
--- a/integration/gcpkms/gcp_kms_client.go
+++ b/integration/gcpkms/gcp_kms_client.go
@@ -24,11 +24,11 @@ import (
 	"runtime"
 	"strings"
 
-	kms "cloud.google.com/go/kms/apiv1"
-	"github.com/tink-crypto/tink-go/v2/core/registry"
-	"github.com/tink-crypto/tink-go/v2/tink"
+	"cloud.google.com/go/kms/apiv1"
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/option"
+	"github.com/tink-crypto/tink-go/v2/core/registry"
+	"github.com/tink-crypto/tink-go/v2/tink"
 )
 
 const (

--- a/integration/gcpkms/gcp_kms_client.go
+++ b/integration/gcpkms/gcp_kms_client.go
@@ -24,11 +24,11 @@ import (
 	"runtime"
 	"strings"
 
-	"cloud.google.com/go/kms/apiv1"
-	"google.golang.org/api/cloudkms/v1"
-	"google.golang.org/api/option"
+	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/tink-crypto/tink-go/v2/core/registry"
 	"github.com/tink-crypto/tink-go/v2/tink"
+	"google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -180,4 +180,12 @@ func (c *Client) GetAEAD(keyURI string) (tink.AEAD, error) {
 	default:
 		return nil, fmt.Errorf("no client present")
 	}
+}
+
+// Close closes the client.
+func (c *Client) Close() error {
+	if c.grpcKMS != nil {
+		return c.grpcKMS.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
Add `Close()` method to KMS Client for proper gRPC connection cleanup.

## Changes
- Add `Close()` method to `Client` struct in `gcp_kms_client.go`
- Properly close gRPC KMS client when available
- Import alias cleanup (`kms "cloud.google.com/go/kms/apiv1"`)

## Why
Prevents potential gRPC connection leaks in long-running applications by providing
explicit resource cleanup.
