### PR TITLE
fix: gcpAEAD to keep *cloudkms.Service

### DIFF
--- a/integration/gcpkms/gcp_kms_aead.go
+++ b/integration/gcpkms/gcp_kms_aead.go
@@ -25,7 +25,7 @@ import (
 // gcpAEAD represents a GCP KMS service to a particular URI.
 type gcpAEAD struct {
 	keyName string
-	kms     cloudkms.Service
+	kms     *cloudkms.Service
 }
 
 var _ tink.AEAD = (*gcpAEAD)(nil)
@@ -34,7 +34,7 @@ var _ tink.AEAD = (*gcpAEAD)(nil)
 func newGCPAEAD(keyName string, kms *cloudkms.Service) tink.AEAD {
 	return &gcpAEAD{
 		keyName: keyName,
-		kms:     *kms,
+		kms:     kms,
 	}
 }
 

--- a/integration/gcpkms/gcp_kms_aead.go
+++ b/integration/gcpkms/gcp_kms_aead.go
@@ -18,8 +18,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/tink-crypto/tink-go/v2/tink"
 	"google.golang.org/api/cloudkms/v1"
+	"github.com/tink-crypto/tink-go/v2/tink"
 )
 
 // gcpAEAD represents a GCP KMS service to a particular URI.

--- a/integration/gcpkms/gcp_kms_aead.go
+++ b/integration/gcpkms/gcp_kms_aead.go
@@ -18,8 +18,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"google.golang.org/api/cloudkms/v1"
 	"github.com/tink-crypto/tink-go/v2/tink"
+	"google.golang.org/api/cloudkms/v1"
 )
 
 // gcpAEAD represents a GCP KMS service to a particular URI.


### PR DESCRIPTION
## Summary
- keep a pointer to cloudkms.Service instead of copying the struct

## Ref
- https://github.com/tink-crypto/tink-go-gcpkms/pull/15#issuecomment-3324529194