### PR TITLE
fix(gcpkms): verify ciphertext_crc32c and AAD_crc32c on Decrypt response

### DIFF
--- a/integration/gcpkms/gcp_kms_aead.go
+++ b/integration/gcpkms/gcp_kms_aead.go
@@ -99,6 +99,12 @@ func (a *gcpAEAD) Decrypt(ciphertext, associatedData []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if !resp.VerifiedCiphertextCrc32c {
+		return nil, fmt.Errorf("KMS request for %q is missing the checksum field ciphertext_crc32c, and other information may be missing from the response. Please retry a limited number of times in case the error is transient", a.keyName)
+	}
+	if !resp.VerifiedAdditionalAuthenticatedDataCrc32c {
+		return nil, fmt.Errorf("KMS request for %q is missing the checksum field additional_authenticated_data_crc32c, and other information may be missing from the response. Please retry a limited number of times in case the error is transient", a.keyName)
+	}
 	plaintext, err := base64.StdEncoding.DecodeString(resp.Plaintext)
 	if err != nil {
 		return nil, err

--- a/integration/gcpkms/gcp_kms_aead_test.go
+++ b/integration/gcpkms/gcp_kms_aead_test.go
@@ -211,6 +211,88 @@ func TestEncrypt_Success(t *testing.T) {
 	}
 }
 
+func TestDecrypt_FailsWhenCiphertextUnverified(t *testing.T) {
+	plaintext := []byte("plaintext")
+	plaintextCrc32c := int64(crc32.Checksum(plaintext, crc32.MakeTable(crc32.Castagnoli)))
+	testcases := []struct {
+		name            string
+		decryptResponse *cloudkms.DecryptResponse
+	}{
+		{
+			name: "verified_ciphertext_crc32c is false",
+			decryptResponse: &cloudkms.DecryptResponse{
+				Plaintext:                                 base64.StdEncoding.EncodeToString(plaintext),
+				PlaintextCrc32c:                           plaintextCrc32c,
+				VerifiedCiphertextCrc32c:                  false,
+				VerifiedAdditionalAuthenticatedDataCrc32c: true,
+			},
+		},
+		{
+			name: "verified_ciphertext_crc32c missing",
+			decryptResponse: &cloudkms.DecryptResponse{
+				Plaintext:                                 base64.StdEncoding.EncodeToString(plaintext),
+				PlaintextCrc32c:                           plaintextCrc32c,
+				VerifiedAdditionalAuthenticatedDataCrc32c: true,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ts, svc := initializeServerWithResponse(ctx, t, tc.decryptResponse)
+			defer ts.Close()
+
+			aead := newGCPAEAD("key name", svc)
+			_, err := aead.Decrypt([]byte("ciphertext"), []byte("additional data"))
+			if err == nil {
+				t.Errorf("a.Decrypt err = nil, want error")
+			}
+		})
+	}
+}
+
+func TestDecrypt_FailsWhenAdditionalAuthenticatedDataUnverified(t *testing.T) {
+	plaintext := []byte("plaintext")
+	plaintextCrc32c := int64(crc32.Checksum(plaintext, crc32.MakeTable(crc32.Castagnoli)))
+	testcases := []struct {
+		name            string
+		decryptResponse *cloudkms.DecryptResponse
+	}{
+		{
+			name: "verified_additional_authenticated_data_crc32c is false",
+			decryptResponse: &cloudkms.DecryptResponse{
+				Plaintext:                                 base64.StdEncoding.EncodeToString(plaintext),
+				PlaintextCrc32c:                           plaintextCrc32c,
+				VerifiedCiphertextCrc32c:                  true,
+				VerifiedAdditionalAuthenticatedDataCrc32c: false,
+			},
+		},
+		{
+			name: "verified_additional_authenticated_data_crc32c missing",
+			decryptResponse: &cloudkms.DecryptResponse{
+				Plaintext:                base64.StdEncoding.EncodeToString(plaintext),
+				PlaintextCrc32c:          plaintextCrc32c,
+				VerifiedCiphertextCrc32c: true,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ts, svc := initializeServerWithResponse(ctx, t, tc.decryptResponse)
+			defer ts.Close()
+
+			aead := newGCPAEAD("key name", svc)
+			_, err := aead.Decrypt([]byte("ciphertext"), []byte("additional data"))
+			if err == nil {
+				t.Errorf("a.Decrypt err = nil, want error")
+			}
+		})
+	}
+}
+
 func TestDecrypt_FailsWithInvalidPlaintextCrc32c(t *testing.T) {
 	testcases := []struct {
 		name            string
@@ -219,14 +301,18 @@ func TestDecrypt_FailsWithInvalidPlaintextCrc32c(t *testing.T) {
 		{
 			name: "plaintext_crc32c does not match plaintext",
 			decryptResponse: &cloudkms.DecryptResponse{
-				Plaintext:       base64.StdEncoding.EncodeToString([]byte("plaintext")),
-				PlaintextCrc32c: int64(1),
+				Plaintext:                                 base64.StdEncoding.EncodeToString([]byte("plaintext")),
+				PlaintextCrc32c:                           int64(1),
+				VerifiedCiphertextCrc32c:                  true,
+				VerifiedAdditionalAuthenticatedDataCrc32c: true,
 			},
 		},
 		{
 			name: "plaintext_crc32c missing",
 			decryptResponse: &cloudkms.DecryptResponse{
-				Plaintext: base64.StdEncoding.EncodeToString([]byte("plaintext")),
+				Plaintext:                                 base64.StdEncoding.EncodeToString([]byte("plaintext")),
+				VerifiedCiphertextCrc32c:                  true,
+				VerifiedAdditionalAuthenticatedDataCrc32c: true,
 			},
 		},
 	}
@@ -254,8 +340,10 @@ func TestDecrypt_Success(t *testing.T) {
 	ctx := context.Background()
 	ts, svc := initializeServerWithResponse(ctx, t,
 		&cloudkms.DecryptResponse{
-			Plaintext:       base64.StdEncoding.EncodeToString(plaintext),
-			PlaintextCrc32c: plaintextCrc32c,
+			Plaintext:                                 base64.StdEncoding.EncodeToString(plaintext),
+			PlaintextCrc32c:                           plaintextCrc32c,
+			VerifiedCiphertextCrc32c:                  true,
+			VerifiedAdditionalAuthenticatedDataCrc32c: true,
 		})
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary

`gcpAEAD.Encrypt()` already enforces Google's [Cloud KMS data-integrity guidelines](https://cloud.google.com/kms/docs/data-integrity-guidelines#calculating_and_verifying_checksums) by erroring out when `resp.VerifiedPlaintextCrc32c` or `resp.VerifiedAdditionalAuthenticatedDataCrc32c` is false (lines 63-68). `gcpAEAD.Decrypt()` populates the request-side `ciphertext_crc32c` / `additional_authenticated_data_crc32c` and the function comment cites the same guidelines, but the response-side gates were missing.

If Cloud KMS could not verify the request-side checksums (echoing `verified_ciphertext_crc32c = false` or `verified_additional_authenticated_data_crc32c = false`), the previous Decrypt path proceeded as if integrity verification had succeeded.

This PR makes Decrypt() symmetric with Encrypt(): error out when either response-side `Verified*Crc32c` field is false or missing.

## Changes

- `integration/gcpkms/gcp_kms_aead.go` — add two checks immediately after the Decrypt RPC, mirroring the Encrypt path
- `integration/gcpkms/gcp_kms_aead_test.go` — add `TestDecrypt_FailsWhenCiphertextUnverified` and `TestDecrypt_FailsWhenAdditionalAuthenticatedDataUnverified` (mirroring the existing Encrypt versions); update existing `TestDecrypt_Success` and `TestDecrypt_FailsWithInvalidPlaintextCrc32c` to set the new `Verified*Crc32c` fields explicitly so they continue to pass

## Test plan

- [x] New unit tests added: `TestDecrypt_FailsWhenCiphertextUnverified`, `TestDecrypt_FailsWhenAdditionalAuthenticatedDataUnverified`
- [x] Existing tests updated to set the new fields where they expect success
- [ ] CI: `go test ./integration/gcpkms/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)